### PR TITLE
Fixes #7 - Adds the option to load custom rules for HTMLHint to hint …

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -12,6 +12,18 @@ module.exports = function(grunt) {
                     }
                 },
                 src: ['test/*.html']
+            },
+            custom: {
+                options: {
+                    customRules: [
+                        'rules/foobar-exists.js',
+                        'rules/bad-rule.js'
+                    ],
+                    rules: {
+                        "foobar-exists": true // custom rule that is loaded above
+                    }
+                },
+                src: ['test/*.html']
             }
         }
     });

--- a/README.md
+++ b/README.md
@@ -77,6 +77,10 @@ Only hint changed file and new file. Default `true`.
 
 Ignore strings between key and value from this object. Default `{}`.
 
+### options.customRules {Array}
+
+An array of paths to custom rule files to load and use in your HTMLHinting. See [issue #47](https://github.com/yaniswang/HTMLHint/issues/47) on the [HTMLHint project](https://github.com/yaniswang/HTMLHint). For examples of how to write a custom rule.
+
 ## Usage Examples
 
 ### Basic
@@ -87,8 +91,12 @@ htmlhintplus: {
     build: {
         options: {
             rules: {
-                'tag-pair': true
-            }
+                'tag-pair': true,
+                'custom-rule': true
+            },
+            customRules: [
+                'rules/custom-rule.js'
+            ]
         }
         src: 'path/to/file'
     }
@@ -143,6 +151,7 @@ grunt test
 
 ## History
 
+- Ver 0.2.0 Adds the option to load custom HTMLHint rules
 - Ver 0.1.0
     - Use [file-changed](https://github.com/poppinlp/file-changed) to do newer job
     - Reconstruct whole project, make it easy to use
@@ -159,4 +168,3 @@ grunt test
     - Support path filter
 - Ver 0.0.2 Fix global options not work
 - Ver 0.0.1 Main
-

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "grunt-htmlhint-plus",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Grunt task to hint html code.",
   "main": "tasks/htmlhintplus.js",
   "repository": {

--- a/rules/bad-rule.js
+++ b/rules/bad-rule.js
@@ -1,0 +1,3 @@
+module.exports = function() {
+  // this won't work
+}

--- a/rules/foobar-exists.js
+++ b/rules/foobar-exists.js
@@ -1,0 +1,15 @@
+module.exports = {
+    id: 'foobar-exists',
+    description: 'Checks that the data-foobar attribute exists on the html element',
+    init: function(parser, reporter){
+        var self = this;
+        parser.addListener('tagstart', function(event){
+            var tagName = event.tagName.toLowerCase(),
+                mapAttrs = parser.getMapAttrs(event.attrs),
+                col = event.col + tagName.length + 1;
+            if(tagName === 'html' && !('data-foobar' in mapAttrs)){
+                reporter.warn('data-foobar of html tag must be present.', event.line, col, self, event.raw);
+            }
+        });
+    }
+};

--- a/tasks/htmlhintplus.js
+++ b/tasks/htmlhintplus.js
@@ -35,7 +35,29 @@ module.exports = function(grunt) {
                 "attr-unsafe-chars": true
             },
             options = this.options(),
-            hasError = false;
+            hasError = false,
+            customRules = [];
+
+        if (options.hasOwnProperty('customRules') && typeof options.customRules == 'object') {
+            customRules = options.customRules;
+        }
+
+        // load custom rules
+        if (customRules.length) {
+            for (var i = 0, len = customRules.length; i < len; i++) {
+                var customRule = require(process.env.PWD + '/' + customRules[i]);
+                if (
+                  typeof customRule == 'object' &&
+                  customRule.hasOwnProperty('id') &&
+                  customRule.hasOwnProperty('description') &&
+                  customRule.hasOwnProperty('init')
+                ) {
+                    HTMLHint.addRule(customRule);
+                } else {
+                    console.error("[error]".red.bold, customRules[i].bold, "was invalid and could not be loaded.".red);
+                }
+            }
+        }
 
         this.files.map(function (files) {
             files.src.map(function (file) {

--- a/test/index2.html
+++ b/test/index2.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html>
+<html data-foobar="hello world!">
 <head>
     <title>foo</title>
 </head>


### PR DESCRIPTION
This pull request adds the option `customRules` to load custom rules for HTMLHint to use when hinting HTML files. A usage case has been added to the README.
