### PR TITLE
Extend rules

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -11,7 +11,7 @@ module.exports = function(grunt) {
                         '{{': '}}'
                     }
                 },
-                src: ['test/*.html']
+                src: [ 'test/*.html' ]
             },
             custom: {
                 options: {
@@ -23,7 +23,18 @@ module.exports = function(grunt) {
                         "foobar-exists": true // custom rule that is loaded above
                     }
                 },
-                src: ['test/*.html']
+                src: [ 'test/*.html' ]
+            },
+            extendRules: {
+                options: {
+                    rules: {
+                        "doctype-first": false,
+                        "tag-pair": false,
+                        "tag-self-close": true,
+                        "spec-char-escape": false
+                    }
+                },
+                src: [ 'test/*.html' ]
             }
         }
     });

--- a/README.md
+++ b/README.md
@@ -81,6 +81,10 @@ Ignore strings between key and value from this object. Default `{}`.
 
 An array of paths to custom rule files to load and use in your HTMLHinting. See [issue #47](https://github.com/yaniswang/HTMLHint/issues/47) on the [HTMLHint project](https://github.com/yaniswang/HTMLHint). For examples of how to write a custom rule.
 
+### options.extendRules {Boolean}
+
+Extend the default rules instead of only running the rules specified. Default `false`.
+
 ## Usage Examples
 
 ### Basic
@@ -96,7 +100,8 @@ htmlhintplus: {
             },
             customRules: [
                 'rules/custom-rule.js'
-            ]
+            ],
+            extendRules: true
         }
         src: 'path/to/file'
     }
@@ -151,6 +156,7 @@ grunt test
 
 ## History
 
+- Ver 0.3.0 Adds the option to extend the default rules instead of overriding them
 - Ver 0.2.0 Adds the option to load custom HTMLHint rules
 - Ver 0.1.0
     - Use [file-changed](https://github.com/poppinlp/file-changed) to do newer job

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "grunt-htmlhint-plus",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Grunt task to hint html code.",
   "main": "tasks/htmlhintplus.js",
   "repository": {
@@ -32,7 +32,8 @@
   },
   "dependencies": {
     "file-changed": "^0.1.0",
-    "htmlhint": ">=0.9.7"
+    "htmlhint": ">=0.9.7",
+    "lodash": "^4.11.1"
   },
   "devDependencies": {
     "grunt": ">=0.4.0"

--- a/tasks/htmlhintplus.js
+++ b/tasks/htmlhintplus.js
@@ -12,6 +12,7 @@ module.exports = function(grunt) {
     grunt.registerMultiTask('htmlhintplus', 'Validate html files with htmlhint.', function () {
         var HTMLHint = require("htmlhint").HTMLHint,
             fc = require('file-changed'),
+            _ = require('lodash'),
             defaultRules = {
                 "tagname-lowercase": true,
                 "attr-lowercase": true,
@@ -36,7 +37,8 @@ module.exports = function(grunt) {
             },
             options = this.options(),
             hasError = false,
-            customRules = [];
+            customRules = [],
+            extendRules = options.extendRules || false;
 
         if (options.hasOwnProperty('customRules') && typeof options.customRules == 'object') {
             customRules = options.customRules;
@@ -81,7 +83,11 @@ module.exports = function(grunt) {
                 if (options.htmlhintrc) {
                     rules = grunt.file.readJSON(options.htmlhintrc);
                 } else if (options.rules) {
-                    rules = options.rules;
+                    if (extendRules) {
+                        rules = _.extend(defaultRules, options.rules);
+                    } else {
+                        rules = options.rules;
+                    }
                 }
 
                 result = HTMLHint.verify(text, rules);

--- a/test/index2.html
+++ b/test/index2.html
@@ -11,5 +11,6 @@
         {% endfor %}
     </ul>
     <p>test</p>
+    <hr>
 </body>
 </html>


### PR DESCRIPTION
The `extendRules` option adds the ability to extend the default rules instead of overriding them when this options value is truthy in the config file. By default, the rules are still overridden.
