### PR TITLE
improve how the path to the custom rules is resolved

### DIFF
--- a/tasks/htmlhintplus.js
+++ b/tasks/htmlhintplus.js
@@ -55,7 +55,7 @@ module.exports = function(grunt) {
         // load custom rules
         if (customRules.length) {
             for (var i = 0, len = customRules.length; i < len; i++) {
-                var customRule = require(process.env.PWD + '/' + customRules[i]);
+                var customRule = require(process.cwd() + '/' + customRules[i]);
                 if (
                   typeof customRule == 'object' &&
                   customRule.hasOwnProperty('id') &&


### PR DESCRIPTION
When used in combination of a git-hook process.env.PWD returns the path to the folder where the script has been initiated.
This results in the inability to run the git-hook from any other directory.

For example git push (which triggers the git-hook) can only be executed from the "root" folder of the project.

When we change this to process.cwd() we will always get the folder where the Gruntfile.js is located.
This makes it possible to then trigger the git-hook in any folder of the project.