### PR TITLE
change to verbose for success, publish new version

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,7 @@ grunt test
 
 ## History
 
+- Ver 0.4.3 Changes the default for logging to not include successful files; moves success to verbose
 - Ver 0.4.2 Merge [PR](https://github.com/poppinlp/grunt-htmlhint-plus/pull/15)
 - Ver 0.4.1 Bugfix for [issue](https://github.com/poppinlp/grunt-htmlhint-plus/issues/12)
 - Ver 0.4.0 Adds the option to output the error reports to files

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "grunt-htmlhint-plus",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "description": "Grunt task to hint html code.",
   "main": "tasks/htmlhintplus.js",
   "repository": {

--- a/tasks/htmlhintplus.js
+++ b/tasks/htmlhintplus.js
@@ -109,7 +109,7 @@ module.exports = function(grunt) {
                     if (options.newer) {
                         fc.addFile(file).update(file);
                     }
-                    grunt.log.ok('HtmlHintPlus: ' + file + ' hint well...');
+                    grunt.verbose.ok('HtmlHintPlus: ' + file + ' hint well...');
                 }
 
                 // update the reduced results collection with this file's info


### PR DESCRIPTION
Resolve issue #17 by changing the logging for successfully hinted files to only print when verbose logging is enabled. This makes it much easier to see errors, and retains the ability for the full report by using verbose grunt logging.

Publish a new version of the package for consumption. 