### PR TITLE
Fixes #20: Support custom rules as documented on htmlhint

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -13,6 +13,17 @@ module.exports = function(grunt) {
                 },
                 src: [ 'test/*.html' ]
             },
+            customAsFunction: {
+                options: {
+                    customRules: [
+                        'rules/foobar-exists-as-function'
+                    ],
+                    rules: {
+                        'foobar-exists-as-function': true
+                    }
+                },
+                src: [ 'test/*.html' ]
+            },
             custom: {
                 options: {
                     customRules: [

--- a/rules/bad-rule.js
+++ b/rules/bad-rule.js
@@ -1,3 +1,3 @@
-module.exports = function() {
+module.exports = {
   // this won't work
 }

--- a/rules/foobar-exists-as-function.js
+++ b/rules/foobar-exists-as-function.js
@@ -1,0 +1,9 @@
+var foobarExists = require('./foobar-exists');
+
+module.exports = function ruleAsFunction(HTMLHint) {
+    HTMLHint.addRule({
+        id: 'foobar-exists-as-function',
+        description: foobarExists.description,
+        init: foobarExists.init,
+    });
+}

--- a/tasks/htmlhintplus.js
+++ b/tasks/htmlhintplus.js
@@ -56,7 +56,9 @@ module.exports = function(grunt) {
         if (customRules.length) {
             for (var i = 0, len = customRules.length; i < len; i++) {
                 var customRule = require(process.cwd() + '/' + customRules[i]);
-                if (
+                if (typeof customRule == 'function') {
+                    customRule(HTMLHint);
+                } else if (
                   typeof customRule == 'object' &&
                   customRule.hasOwnProperty('id') &&
                   customRule.hasOwnProperty('description') &&


### PR DESCRIPTION
This will forward HTMLHint into a custom rule function as documented https://github.com/yaniswang/HTMLHint/wiki/Usage#load-custom-rules.

We could also pass in the rule from the function to your validation but I feel it's HtmlHints responsibility to tell us what's valid. e.g,

```javascript
if (typeof customRule === 'function') {
    customRule({
        addRule: addRule
    });
} else {
    addRule(customRule);
}
function addRule(rule) {
    // existing validation
}
```

As for tests let me know if this is not adequate